### PR TITLE
hotfix : fix create workSession status code

### DIFF
--- a/src/modules/workSession/controller/workSession.controller.ts
+++ b/src/modules/workSession/controller/workSession.controller.ts
@@ -55,7 +55,7 @@ export class WorkSessionController {
       dto,
     );
 
-    const statusCode = latestWorkSession.isUnfinished ? 200 : 204;
+    const statusCode = latestWorkSession.isUnfinished ? 204 : 200;
 
     return res.status(statusCode).json({
       isUnfinished: latestWorkSession.isUnfinished,

--- a/src/modules/workSession/controller/workSession.controller.ts
+++ b/src/modules/workSession/controller/workSession.controller.ts
@@ -55,7 +55,7 @@ export class WorkSessionController {
       dto,
     );
 
-    const statusCode = latestWorkSession.isUnfinished ? 204 : 200;
+    const statusCode = latestWorkSession.isUnfinished ? 200 : 201;
 
     return res.status(statusCode).json({
       isUnfinished: latestWorkSession.isUnfinished,


### PR DESCRIPTION
### Before
When unfinished workSession is already exists, return status code **200**
When there's no unfinished workSession, return status code **204**

This was causing a bug on creating workSession, since when status code is 204, Server doesn't return any content even though it succesfully creates & saves WorkSession. 

### After
When unfinished workSession is already exists, return status code **204**
When there's no unfinished workSession, return status code **200**

